### PR TITLE
use rate instead of irate

### DIFF
--- a/hpa/prometheus-adapter.yml
+++ b/hpa/prometheus-adapter.yml
@@ -10,7 +10,7 @@ rules:
       name:
         matches: ^(.*)_bucket$
         as: "${1}_50th"
-      metricsQuery: histogram_quantile(0.50, sum(irate(<<.Series>>{<<.LabelMatchers>>, direction="inbound"}[5m])) by (le, <<.GroupBy>>))
+      metricsQuery: histogram_quantile(0.50, sum(rate(<<.Series>>{<<.LabelMatchers>>, direction="inbound"}[5m])) by (le, <<.GroupBy>>))
 
     - seriesQuery: 'response_latency_ms_bucket{namespace!="",pod!=""}'
       resources:
@@ -18,7 +18,7 @@ rules:
       name:
         matches: ^(.*)_bucket$
         as: "${1}_95th"
-      metricsQuery: histogram_quantile(0.95, sum(irate(<<.Series>>{<<.LabelMatchers>>, direction="inbound"}[5m])) by (le, <<.GroupBy>>))
+      metricsQuery: histogram_quantile(0.95, sum(rate(<<.Series>>{<<.LabelMatchers>>, direction="inbound"}[5m])) by (le, <<.GroupBy>>))
 
     - seriesQuery: 'response_latency_ms_bucket{namespace!="",pod!=""}'
       resources:
@@ -26,7 +26,7 @@ rules:
       name:
         matches: ^(.*)_bucket$
         as: "${1}_99th"
-      metricsQuery: histogram_quantile(0.99, sum(irate(<<.Series>>{<<.LabelMatchers>>, direction="inbound"}[5m])) by (le, <<.GroupBy>>))
+      metricsQuery: histogram_quantile(0.99, sum(rate(<<.Series>>{<<.LabelMatchers>>, direction="inbound"}[5m])) by (le, <<.GroupBy>>))
 
     - seriesQuery: 'request_total{namespace!="",pod!=""}'
       resources:
@@ -36,7 +36,7 @@ rules:
         as: "${1}s_per_second"
       metricsQuery: |-
         sum(
-          irate(
+          rate(
             <<.Series>>{
               <<.LabelMatchers>>,
               direction="inbound"

--- a/hpa/prometheus-config.yml
+++ b/hpa/prometheus-config.yml
@@ -5,13 +5,13 @@ data:
       - name: latency
         rules:
           - record: job:response_latency_ms:50th
-            expr: histogram_quantile(0.50, sum(irate(response_latency_ms_bucket{namespace!="",pod!="", direction="inbound"}[5m])) by (le, pod, namespace))
+            expr: histogram_quantile(0.50, sum(rate(response_latency_ms_bucket{namespace!="",pod!="", direction="inbound"}[5m])) by (le, pod, namespace))
 
           - record: job:response_latency_ms:95th
-            expr: histogram_quantile(0.95, sum(irate(response_latency_ms_bucket{namespace!="",pod!="", direction="inbound"}[5m])) by (le, pod, namespace))
+            expr: histogram_quantile(0.95, sum(rate(response_latency_ms_bucket{namespace!="",pod!="", direction="inbound"}[5m])) by (le, pod, namespace))
 
           - record: job:response_latency_ms:99th
-            expr: histogram_quantile(0.99, sum(irate(response_latency_ms_bucket{namespace!="",pod!="", direction="inbound"}[5m])) by (le, pod, namespace))
+            expr: histogram_quantile(0.99, sum(rate(response_latency_ms_bucket{namespace!="",pod!="", direction="inbound"}[5m])) by (le, pod, namespace))
 
   prometheus.yml: |-
     rule_files:


### PR DESCRIPTION
The use of rate produces smoother time series resulting in less jittery autoscaling
